### PR TITLE
Ensure camera device forgotten when closed fully

### DIFF
--- a/SonyMTPCamera/Camera.cpp
+++ b/SonyMTPCamera/Camera.cpp
@@ -36,10 +36,10 @@ Camera::Open()
     return m_device->Open();
 }
 
-void
+bool
 Camera::Close()
 {
-    m_device->Close();
+    return m_device->Close();
 }
 
 DeviceInfo*

--- a/SonyMTPCamera/Camera.h
+++ b/SonyMTPCamera/Camera.h
@@ -83,7 +83,7 @@ public:
 
     const std::wstring GetId();
     HANDLE Open();
-    void Close();
+    bool Close();
 
     virtual DeviceInfo* GetDeviceInfo();
     virtual bool SetProperty(Property id, PropertyValue* value) = 0;

--- a/SonyMTPCamera/DLL.cpp
+++ b/SonyMTPCamera/DLL.cpp
@@ -209,7 +209,11 @@ CloseDevice(HANDLE hCamera)
     {
         Locker lock(camera);
 
-        camera->Close();
+        if (camera->Close())
+        {
+            // This happens if the device is fully closed
+            GetCameraManager()->RemoveCamera(camera);
+        }
     }
     catch (CameraException & gfe)
     {

--- a/SonyMTPCamera/Device.cpp
+++ b/SonyMTPCamera/Device.cpp
@@ -130,6 +130,8 @@ Device::Close()
 {
     LOGTRACE(L"In: Device::Close");
 
+    bool closed;
+
     if (m_openCount)
     {
         if (m_openCount == 1)
@@ -149,7 +151,7 @@ Device::Close()
 
                 LOGTRACE(L"Out: Device::Close - Closed()");
 
-                return true;
+                closed = true;
             }
         }
         else
@@ -158,13 +160,13 @@ Device::Close()
 
             LOGTRACE(L"Out: Device::Close - Still open, opencount reduced to %d", m_openCount);
 
-            return true;
+            closed = false;
         }
     }
 
-    LOGWARN(L"Out: Device::Close - Attempt to close device that is not open");
+    LOGWARN(L"Out: Device::Close (result = %d)", closed);
 
-    return false;
+    return closed;
 }
 
 bool


### PR DESCRIPTION
When device was closed and openCount reached zero, it would be retained in the list of active cameras - rendering it unable to be reopened.  This ensures when the opencount reaches zero it is removed from the list